### PR TITLE
agrego filtro a productos

### DIFF
--- a/src/features/product-module/product/dto/product-query.dto.ts
+++ b/src/features/product-module/product/dto/product-query.dto.ts
@@ -8,7 +8,9 @@ import {
 	IsOptional,
 	IsPositive,
 	IsString,
+	IsArray
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class ProductQueryDto extends PaginationQueryDto {
 	@ApiPropertyOptional()
@@ -53,4 +55,13 @@ export class ProductQueryDto extends PaginationQueryDto {
 	@IsNumber()
 	@IsPositive()
 	maxPrice?: number;
+
+
+	@ApiPropertyOptional()
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	@Transform(({ value }) => Array.isArray(value) ? value : value.split(',').map(tag => tag.trim()))
+	tags?: string[];
 }
+

--- a/src/features/product-module/product/product.service.ts
+++ b/src/features/product-module/product/product.service.ts
@@ -53,7 +53,7 @@ export class ProductService {
 			category: query.category,
 			cost: { gte: query.minCost, lte: query.maxCost },
 			price: { amount: { gte: query.minPrice, lte: query.maxPrice } },
-		};
+			tags: query.tags ? {some: {tag: {name: { in: query.tags }}}} : undefined,};
 		const [data, total] = await Promise.all([
 			this.db.product.findMany({
 				...this.db.paginate(query),


### PR DESCRIPTION
- La funcionalidad permite buscar productos que coincidan con al menos uno de los tags especificados
-  Los usuarios pueden elegir buscar productos con un solo tag o con una combinación de varios tag