### PR TITLE
[351] filtrar movimiento por nombre de producto

### DIFF
--- a/src/features/stock-module/movement/dto/movement/movement-query.dto.ts
+++ b/src/features/stock-module/movement/dto/movement/movement-query.dto.ts
@@ -56,4 +56,9 @@ export class MovementQueryDto extends PaginationQueryDto {
 		description: 'ID del stock de destino',
 	})
 	destinationStockId?: number;
+
+	@IsOptional()
+	@IsString()
+	@ApiPropertyOptional()
+	productName?: string;
 }

--- a/src/features/stock-module/movement/movement.service.ts
+++ b/src/features/stock-module/movement/movement.service.ts
@@ -147,9 +147,7 @@ export class MovementService {
 				? {
 						some: {
 							product: {
-								name: dto.productName
-									? { contains: dto.productName, mode: 'insensitive' }
-									: undefined,
+								name: { contains: dto.productName, mode: 'insensitive' },
 							},
 						},
 					}

--- a/src/features/stock-module/movement/movement.service.ts
+++ b/src/features/stock-module/movement/movement.service.ts
@@ -143,6 +143,17 @@ export class MovementService {
 				: undefined,
 			originStockId: dto.originStockId,
 			destinationStockId: dto.destinationStockId,
+			details: dto.productName
+				? {
+						some: {
+							product: {
+								name: dto.productName
+									? { contains: dto.productName, mode: 'insensitive' }
+									: undefined,
+							},
+						},
+					}
+				: undefined,
 		};
 
 		const [data, total] = await Promise.all([
@@ -153,6 +164,11 @@ export class MovementService {
 					manager: { include: { user: true } },
 					originStock: true,
 					destinationStock: true,
+					details: {
+						include: {
+							product: true,
+						},
+					},
 				},
 			}),
 			this.db.movement.count({ where }),

--- a/src/features/stock-module/stock-details/dto/stock-details-query.dto.ts
+++ b/src/features/stock-module/stock-details/dto/stock-details-query.dto.ts
@@ -1,7 +1,7 @@
 import { PaginationQueryDto } from '@lib/commons/pagination-params.dto';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsOptional, IsPositive } from 'class-validator';
 import { Type } from 'class-transformer';
-import { IsNumber, IsOptional, Min } from 'class-validator';
 
 export class StockDetailsQueryDto extends PaginationQueryDto {
 	@IsOptional()
@@ -22,10 +22,19 @@ export class StockDetailsQueryDto extends PaginationQueryDto {
 
 	@IsOptional()
 	@Type(() => Number)
-	@IsNumber()
-	@Min(0)
+	@IsInt()
+	@IsPositive()
 	@ApiPropertyOptional({
-		description: 'Filtrar por cantidad en detalles',
+		description: 'Filtrar desde cierta cantidad de productos en el deposito',
 	})
-	amount?: number;
+	fromAmount?: number;
+
+	@IsOptional()
+	@Type(() => Number)
+	@IsInt()
+	@IsPositive()
+	@ApiPropertyOptional({
+		description: 'Filtrar hasta cierta cantidad de productos en el deposito',
+	})
+	toAmount?: number;
 }


### PR DESCRIPTION
Se puede filtrar los movimientos por nombre del producto
- Agregue en movement-query.dto.ts → productName?: string;
- Agregue en movement.service.ts en filter la búsqueda parcial sin distinguir mayúsculas y minúsculas.