### PR TITLE
relacion de registro de vacunas con una cita

### DIFF
--- a/prisma/migrations/20250528004423_link_vaccine_to_appointment/migration.sql
+++ b/prisma/migrations/20250528004423_link_vaccine_to_appointment/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "VaccineRegistry" ADD COLUMN     "appointmentId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "VaccineRegistry" ADD CONSTRAINT "VaccineRegistry_appointmentId_fkey" FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250530145808_change_datetime_to_date/migration.sql
+++ b/prisma/migrations/20250530145808_change_datetime_to_date/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "VaccineRegistry" ALTER COLUMN "applicationDate" SET DATA TYPE DATE,
+ALTER COLUMN "expectedDate" SET DATA TYPE DATE;

--- a/prisma/schema/appointment.prisma
+++ b/prisma/schema/appointment.prisma
@@ -19,6 +19,7 @@ model Appointment {
     employee           Employee                @relation(fields: [employeeId], references: [id])
 
     notifications Notification[]
+    vaccineRegistry VaccineRegistry[]
 }
 
 model AppointmentDetail {

--- a/prisma/schema/vaccine-registry.prisma
+++ b/prisma/schema/vaccine-registry.prisma
@@ -3,9 +3,9 @@ model VaccineRegistry {
   vaccineId       Int
   petId           Int
   dose            Float
-  applicationDate DateTime?
+  applicationDate DateTime? @db.Date
   appointmentId   Int?  
-  expectedDate    DateTime
+  expectedDate    DateTime  @db.Date
 
   deletedAt DateTime?
   createdAt DateTime  @default(now())

--- a/prisma/schema/vaccine-registry.prisma
+++ b/prisma/schema/vaccine-registry.prisma
@@ -4,6 +4,7 @@ model VaccineRegistry {
   petId           Int
   dose            Float
   applicationDate DateTime?
+  appointmentId   Int?  
   expectedDate    DateTime
 
   deletedAt DateTime?
@@ -13,4 +14,5 @@ model VaccineRegistry {
   notifications Notification[]
   vaccine       Vaccine        @relation(fields: [vaccineId], references: [id])
   pet           Pet            @relation(fields: [petId], references: [id])
+  appointment   Appointment?    @relation(fields: [appointmentId], references: [id])
 }

--- a/src/features/appointment-module/appointment/appointment.mapper.ts
+++ b/src/features/appointment-module/appointment/appointment.mapper.ts
@@ -7,6 +7,8 @@ import {
 	Race,
 	ServiceType,
 	User,
+	VaccineRegistry,
+	Vaccine,
 } from '@prisma/client';
 import { AppointmentDto } from './dto/appointment.dto';
 
@@ -14,6 +16,7 @@ export interface AppointmentEntity extends Appointment {
 	pet: Pet & { race: Race } & { client: Client & { user: User } };
 	employee: Employee & { user: User };
 	appointmentDetails: (AppointmentDetail & { service: ServiceType })[];
+	vaccineRegistry?: (VaccineRegistry & { vaccine: Vaccine })[];
 }
 
 export class AppointmentMapper {
@@ -41,6 +44,18 @@ export class AppointmentMapper {
 					name: data.pet.client.user.fullName,
 				},
 			},
+			vaccineRegistry:
+				data.vaccineRegistry?.map((reg) => ({
+					id: reg.id,
+					petId: reg.petId,
+					dose: reg.dose,
+					applicationDate: reg.applicationDate ?? undefined,
+					expectedDate: reg.expectedDate,
+					vaccine: {
+						id: reg.vaccine.id,
+						name: reg.vaccine.name,
+					},
+				})) ?? [],
 		};
 	}
 }

--- a/src/features/appointment-module/appointment/appointment.service.ts
+++ b/src/features/appointment-module/appointment/appointment.service.ts
@@ -116,6 +116,7 @@ export class AppointmentService {
 				pet: { include: { race: true, client: { include: { user: true } } } },
 				appointmentDetails: { include: { service: true } },
 				employee: { include: { user: true } },
+				vaccineRegistry: { include: { vaccine: true } },
 			},
 		};
 	}

--- a/src/features/appointment-module/appointment/dto/appointment-vaccine-registry.dto.ts
+++ b/src/features/appointment-module/appointment/dto/appointment-vaccine-registry.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AppointmentVaccineDto } from './appointment-vaccine.dto';
+export class VaccineRegistryDto {
+	@ApiProperty()
+	id: number;
+
+	@ApiProperty()
+	petId: number;
+
+	@ApiProperty()
+	dose: number;
+
+	@ApiPropertyOptional()
+	applicationDate?: Date;
+
+	@ApiProperty()
+	expectedDate: Date;
+
+	@ApiProperty({ type: () => AppointmentVaccineDto })
+	vaccine: AppointmentVaccineDto;
+}

--- a/src/features/appointment-module/appointment/dto/appointment-vaccine.dto.ts
+++ b/src/features/appointment-module/appointment/dto/appointment-vaccine.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AppointmentVaccineDto {
+	@ApiProperty()
+	id: number;
+
+	@ApiProperty()
+	name: string;
+}

--- a/src/features/appointment-module/appointment/dto/appointment.dto.ts
+++ b/src/features/appointment-module/appointment/dto/appointment.dto.ts
@@ -3,6 +3,7 @@ import { AppointmentStatus } from '@prisma/client';
 import { AppointmentEmployeeDto } from './appointment-employee.dto';
 import { AppointmentPetDto } from './appointment-pet.dto';
 import { ServiceTypeSummaryDto } from '@features/service-type/dto/service-type-summary.dto';
+import { VaccineRegistryDto } from './appointment-vaccine-registry.dto';
 
 export class AppointmentDto {
 	@ApiProperty()
@@ -28,4 +29,7 @@ export class AppointmentDto {
 
 	@ApiProperty({ type: AppointmentEmployeeDto })
 	employee: AppointmentEmployeeDto;
+
+	@ApiPropertyOptional({ type: [VaccineRegistryDto] })
+	vaccineRegistry?: VaccineRegistryDto[];
 }

--- a/src/features/vaccine-module/vaccine-registry/dto/create-vaccine-registry.dto.ts
+++ b/src/features/vaccine-module/vaccine-registry/dto/create-vaccine-registry.dto.ts
@@ -13,6 +13,9 @@ export class CreateVaccineRegistryDto {
 	@ApiPropertyOptional()
 	@IsNumber()
 	dose: number;
+	@ApiPropertyOptional()
+	@IsOptional()
+	appointmentId?: number;
 
 	@ApiPropertyOptional()
 	@IsOptional()


### PR DESCRIPTION

- Se establece la relación entre las citas (Appointment) y los registros de vacunación (VaccineRegistry) mediante una clave foránea opcional.
- Se actualiza el modelo de datos en Prisma para reflejar esta relación.
- Se agregan los DTOs (VaccineRegistryDto, AppointmentVaccineDto) para incluir la información relevante de vacunación en la respuesta de una cita.
- Se adapta el AppointmentMapper para mapear correctamente los registros de vacunación asociados a una cita.
- Se garantiza que la relación sea opcional, permitiendo que existan citas sin vacunas.